### PR TITLE
Package jars with dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,22 @@
     <defaultGoal>package</defaultGoal>
     <plugins>
       <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.12.1</version>


### PR DESCRIPTION
In using this code (as a jar from another project), I was getting errors like "Can't find class
Jedis".  I don't want to explicitly state the dependencies for this project in my project.  I'd
rather just have a big fat jar with all of the requisite dependencies.

The `assembly:single` plugin is tied to the `package` phase so:
`./qless-java/target/qless-java-0.0.1-SNAPSHOT-jar-with-dependencies.jar` and
`./qless-worker/target/qless-worker-0.0.1-SNAPSHOT-jar-with-dependencies.jar` will be created when
`mvn package` is run