### PR TITLE
Various Tiny Usability Fixes

### DIFF
--- a/qless-java/src/main/java/com/moz/qless/Client.java
+++ b/qless-java/src/main/java/com/moz/qless/Client.java
@@ -63,13 +63,19 @@ public class Client {
     this.queues = new Queues(this);
   }
 
-  public Object call(final String command, final List<String> args) throws IOException {
+  public Object call(final String command, final List<Object> args) throws IOException {
     final List<String> argsList = new ArrayList<String>();
     argsList.add(command);
     argsList.add(ClientHelper.getCurrentSeconds());
 
-    for (final String arg : args) {
-      argsList.add(arg);
+    for (final Object arg : args) {
+      if (arg instanceof List) {
+        for (final Object subArg : (List<Object>) arg) {
+          argsList.add(subArg.toString());
+        }
+      } else {
+        argsList.add(arg.toString());
+      }
     }
 
     Client.LOGGER.debug("{}", argsList);
@@ -77,8 +83,17 @@ public class Client {
     return this.luaScript.call(Client.KEYS_LIST, argsList);
   }
 
-  public Object call(final String command, final String... args) throws IOException {
+  public Object call(final String command, final Object... args) throws IOException {
     return this.call(command, Arrays.asList(args));
+  }
+
+  public Object call(final LuaCommand command, final Object... args) throws IOException {
+    return this.call(command.toString(), args);
+  }
+
+  public Object call(final LuaCommand command, final List<Object> args)
+    throws IOException {
+    return this.call(command.toString(), args);
   }
 
   public List<String> tags(final int offset, final int count) throws IOException {
@@ -88,7 +103,7 @@ public class Client {
         String.valueOf(count));
 
     final Object result = this.call(
-        LuaCommand.TAG.toString(),
+        LuaCommand.TAG,
         params);
 
     final JavaType javaType = new ObjectMapper().getTypeFactory()
@@ -102,15 +117,15 @@ public class Client {
 
   public void track(final String jid) throws IOException {
     this.call(
-        LuaCommand.TRACK.toString(),
-        LuaCommand.TRACK.toString(),
+        LuaCommand.TRACK,
+        LuaCommand.TRACK,
         jid);
   }
 
   public void untrack(final String jid) throws IOException {
     this.call(
-        LuaCommand.TRACK.toString(),
-        LuaCommand.UNTRACK.toString(),
+        LuaCommand.TRACK,
+        LuaCommand.UNTRACK,
         jid);
   }
 
@@ -120,7 +135,7 @@ public class Client {
 
   public void unfail(final String group, final String queue, final int count)
       throws IOException {
-    this.call(LuaCommand.UNFAIL.toString(), queue, group, String.valueOf(count));
+    this.call(LuaCommand.UNFAIL, queue, group, String.valueOf(count));
   }
 
   public String workerName() {

--- a/qless-java/src/main/java/com/moz/qless/Config.java
+++ b/qless-java/src/main/java/com/moz/qless/Config.java
@@ -22,7 +22,7 @@ public class Config {
   }
 
   public Map<String, Object> getMap() throws IOException {
-    final Object result = this.client.call(LuaCommand.CONFIG_GET.toString());
+    final Object result = this.client.call(LuaCommand.CONFIG_GET);
 
     final JavaType javaType = new ObjectMapper().getTypeFactory().constructMapType(
         HashMap.class, String.class, Object.class);
@@ -41,7 +41,7 @@ public class Config {
 
   public Object get(final String key) throws IOException {
       return this.client.call(
-          LuaCommand.CONFIG_GET.toString(),
+          LuaCommand.CONFIG_GET,
           key);
   }
 
@@ -51,9 +51,13 @@ public class Config {
 
   public void put(final String key, final Object value) throws IOException {
     this.client.call(
-        LuaCommand.CONFIG_SET.toString(),
+        LuaCommand.CONFIG_SET,
         key,
         value.toString());
+  }
+
+  public void put(final LuaConfigParameter key, final Object value) throws IOException {
+    this.put(key.toString(), value);
   }
 
   public Object pop(final String key) throws IOException {
@@ -65,7 +69,7 @@ public class Config {
 
   public void remove(final String key) throws IOException {
     this.client.call(
-        LuaCommand.CONFIG_UNSET.toString(),
+        LuaCommand.CONFIG_UNSET,
         key);
   }
 

--- a/qless-java/src/main/java/com/moz/qless/Job.java
+++ b/qless-java/src/main/java/com/moz/qless/Job.java
@@ -98,7 +98,7 @@ public class Job {
 
   public void cancel() throws IOException {
     this.client.call(
-        LuaCommand.CANCEL.toString(),
+        LuaCommand.CANCEL,
         this.jid);
   }
 
@@ -114,24 +114,24 @@ public class Job {
       throws IOException {
     if (null == nextQueueName) {
       this.client.call(
-          LuaCommand.COMPLETE.toString(),
+          LuaCommand.COMPLETE,
           this.jid,
           this.client.workerName(),
           this.queueName,
           JsonUtils.stringify(this.data));
     } else {
       this.client.call(
-          LuaCommand.COMPLETE.toString(),
+          LuaCommand.COMPLETE,
           this.jid,
           this.client.workerName(),
           this.queueName,
           JsonUtils.stringify(this.data),
-          LuaConfigParameter.NEXT.toString(),
+          LuaConfigParameter.NEXT,
           nextQueueName,
-          LuaConfigParameter.DELAY.toString(), MapUtils.get(opts,
+          LuaConfigParameter.DELAY, MapUtils.get(opts,
               LuaConfigParameter.DELAY.toString(),
               ClientHelper.DEFAULT_DELAY),
-          LuaConfigParameter.DEPENDS.toString(),
+          LuaConfigParameter.DEPENDS,
           JsonUtils.stringify(MapUtils.getList(opts,
               LuaConfigParameter.DEPENDS.toString())));
     }
@@ -157,13 +157,13 @@ public class Job {
     args.toArray(array);
 
     this.client.call(
-        LuaCommand.DEPENDS.toString(),
+        LuaCommand.DEPENDS,
         array);
   }
 
   public void fail(final String group, final String message) throws IOException {
     this.client.call(
-        LuaCommand.FAIL.toString(),
+        LuaCommand.FAIL,
         this.jid,
         this.client.workerName(),
         group,
@@ -260,7 +260,7 @@ public class Job {
 
   public long heartbeat() throws IOException {
     try {
-      this.expires = (Long) this.client.call(LuaCommand.HEARTBEAT.toString(), this.jid,
+      this.expires = (Long) this.client.call(LuaCommand.HEARTBEAT, this.jid,
           this.worker, JsonUtils.stringify(this.data));
       return this.expires;
     } catch (final JedisDataException ex) {
@@ -274,7 +274,7 @@ public class Job {
 
   public void log(final String message) throws IOException {
     this.client.call(
-        LuaCommand.LOG.toString(),
+        LuaCommand.LOG,
         this.jid,
         message);
   }
@@ -299,7 +299,7 @@ public class Job {
   public void log(final String message, final Map<String, Object> data)
       throws IOException {
     this.client.call(
-        LuaCommand.LOG.toString(),
+        LuaCommand.LOG,
         this.jid,
         message,
         JsonUtils.stringify(data));
@@ -307,9 +307,9 @@ public class Job {
 
   public void priority(final int priority) throws IOException {
     this.client.call(
-        LuaCommand.PRIORITY.toString(),
+        LuaCommand.PRIORITY,
         this.jid,
-        Integer.toString(priority));
+        priority);
     this.priority = priority;
   }
 
@@ -371,7 +371,7 @@ public class Job {
       throws IOException {
     try {
     this.client.call(
-        LuaCommand.REQUEUE.toString(),
+        LuaCommand.REQUEUE,
         this.client.workerName(),
         queueName,
         this.jid,
@@ -379,17 +379,17 @@ public class Job {
         JsonUtils.stringify(this.data),
         MapUtils.get(
             opts, LuaConfigParameter.DELAY.toString(), ClientHelper.DEFAULT_DELAY),
-        LuaConfigParameter.PRIORITY.toString(),
+        LuaConfigParameter.PRIORITY,
         MapUtils.get(
             opts, LuaConfigParameter.PRIORITY.toString(),
             Integer.toString(this.priority)),
-        LuaConfigParameter.TAGS.toString(),
+        LuaConfigParameter.TAGS,
         JsonUtils.stringify(
             MapUtils.getList(opts, LuaConfigParameter.TAGS.toString(), this.tags)),
-        LuaConfigParameter.RETRIES.toString(),
+        LuaConfigParameter.RETRIES,
         MapUtils.get(
             opts, LuaConfigParameter.RETRIES.toString(), ClientHelper.DEFAULT_RETRIES),
-        LuaConfigParameter.DEPENDS.toString(),
+        LuaConfigParameter.DEPENDS,
         JsonUtils.stringify(MapUtils.getList(
             opts, LuaConfigParameter.DEPENDS.toString(), this.getDependencies())));
     } catch (final JedisDataException ex) {
@@ -413,18 +413,18 @@ public class Job {
       throws IOException {
     if (Strings.isNullOrEmpty(group)) {
       this.client.call(
-          LuaCommand.RETRY.toString(),
+          LuaCommand.RETRY,
           this.jid,
           this.queueName,
           this.worker,
-          Integer.toString(delay));
+          delay);
     } else {
       this.client.call(
-          LuaCommand.RETRY.toString(),
+          LuaCommand.RETRY,
           this.jid,
           this.queueName,
           this.worker,
-          Integer.toString(delay),
+          delay,
           group,
           message);
     }
@@ -438,7 +438,7 @@ public class Job {
     Collections.addAll(args, tags);
 
     this.client.call(
-        LuaCommand.TAG.toString(),
+        LuaCommand.TAG,
         args);
   }
 
@@ -460,8 +460,8 @@ public class Job {
 
   public void track() throws IOException {
     this.client.call(
-        LuaCommand.TRACK.toString(),
-        LuaCommand.TRACK.toString(),
+        LuaCommand.TRACK,
+        LuaCommand.TRACK,
         this.jid);
     this.tracked = true;
   }
@@ -477,7 +477,7 @@ public class Job {
     args.toArray(array);
 
     this.client.call(
-        LuaCommand.DEPENDS.toString(),
+        LuaCommand.DEPENDS,
         array);
   }
 
@@ -489,14 +489,14 @@ public class Job {
     Collections.addAll(args, tags);
 
     this.client.call(
-        LuaCommand.TAG.toString(),
+        LuaCommand.TAG,
         args);
   }
 
   public void untrack() throws IOException {
     this.client.call(
-        LuaCommand.TRACK.toString(),
-        LuaCommand.UNTRACK.toString(),
+        LuaCommand.TRACK,
+        LuaCommand.UNTRACK,
         this.jid);
     this.tracked = false;
   }

--- a/qless-java/src/main/java/com/moz/qless/Job.java
+++ b/qless-java/src/main/java/com/moz/qless/Job.java
@@ -130,7 +130,7 @@ public class Job {
           nextQueueName,
           LuaConfigParameter.DELAY, MapUtils.get(opts,
               LuaConfigParameter.DELAY.toString(),
-              ClientHelper.DEFAULT_DELAY),
+              ClientHelper.DEFAULT_DELAY.toString()),
           LuaConfigParameter.DEPENDS,
           JsonUtils.stringify(MapUtils.getList(opts,
               LuaConfigParameter.DEPENDS.toString())));
@@ -377,18 +377,20 @@ public class Job {
         this.jid,
         this.klass,
         JsonUtils.stringify(this.data),
-        MapUtils.get(
-            opts, LuaConfigParameter.DELAY.toString(), ClientHelper.DEFAULT_DELAY),
+        MapUtils.get(opts,
+          LuaConfigParameter.DELAY.toString(),
+          ClientHelper.DEFAULT_DELAY.toString()),
         LuaConfigParameter.PRIORITY,
-        MapUtils.get(
-            opts, LuaConfigParameter.PRIORITY.toString(),
-            Integer.toString(this.priority)),
+        MapUtils.get(opts,
+          LuaConfigParameter.PRIORITY.toString(),
+          Integer.toString(this.priority)),
         LuaConfigParameter.TAGS,
         JsonUtils.stringify(
-            MapUtils.getList(opts, LuaConfigParameter.TAGS.toString(), this.tags)),
+          MapUtils.getList(opts, LuaConfigParameter.TAGS.toString(), this.tags)),
         LuaConfigParameter.RETRIES,
-        MapUtils.get(
-            opts, LuaConfigParameter.RETRIES.toString(), ClientHelper.DEFAULT_RETRIES),
+        MapUtils.get(opts,
+          LuaConfigParameter.RETRIES.toString(),
+          ClientHelper.DEFAULT_RETRIES.toString()),
         LuaConfigParameter.DEPENDS,
         JsonUtils.stringify(MapUtils.getList(
             opts, LuaConfigParameter.DEPENDS.toString(), this.getDependencies())));

--- a/qless-java/src/main/java/com/moz/qless/Job.java
+++ b/qless-java/src/main/java/com/moz/qless/Job.java
@@ -144,6 +144,11 @@ public class Job {
     return (T) this.data.get(key);
   }
 
+  @SuppressWarnings("unchecked")
+  public <T> T getDataField(final Class<T> clazz, final String key) {
+    return (T) this.data.get(key);
+  }
+
   public void setDataField(final String key, final Object value) throws IOException {
     this.data.put(key, value);
   }

--- a/qless-java/src/main/java/com/moz/qless/Job.java
+++ b/qless-java/src/main/java/com/moz/qless/Job.java
@@ -137,8 +137,9 @@ public class Job {
     }
   }
 
-  public Object getDataField(final String key) {
-    return this.data.get(key);
+  @SuppressWarnings("unchecked")
+  public <T> T getDataField(final String key) {
+    return (T) this.data.get(key);
   }
 
   public void setDataField(final String key, final Object value) throws IOException {

--- a/qless-java/src/main/java/com/moz/qless/Queue.java
+++ b/qless-java/src/main/java/com/moz/qless/Queue.java
@@ -33,14 +33,14 @@ public class Queue {
 
   public QueueCounts getCounts() throws IOException {
     final Object result = this.client.call(
-        LuaCommand.QUEUES.toString(),
+        LuaCommand.QUEUES,
         this.name);
 
     return JsonUtils.parse(result.toString(), QueueCounts.class);
   }
 
   private String getHeartbeatConfigName() {
-    return this.name + "-" + LuaConfigParameter.HEARTBEAT.toString();
+    return this.name + "-" + LuaConfigParameter.HEARTBEAT;
   }
 
   public int getHeartbeat() throws IOException {
@@ -70,7 +70,7 @@ public class Queue {
 
   public Map<String, Object> getStats(final Date date) throws IOException {
     final Object result = this.client.call(
-        LuaCommand.STATS.toString(),
+        LuaCommand.STATS,
         this.name,
         String.valueOf(date.getTime() / 1000));
 
@@ -108,12 +108,12 @@ public class Queue {
 
   public void pause(final boolean timeoutRunningJobs) throws IOException {
     this.client.call(
-        LuaCommand.PAUSE.toString(),
+        LuaCommand.PAUSE,
         this.name);
 
     if (timeoutRunningJobs) {
     this.client.call(
-        LuaCommand.TIMEOUT.toString(),
+        LuaCommand.TIMEOUT,
         this.jobs().running(0, -1));
     }
   }
@@ -131,9 +131,9 @@ public class Queue {
     Preconditions.checkArgument(count > 0, "Negative job count");
 
     final Object result = this.client.call(
-        LuaCommand.PEEK.toString(),
+        LuaCommand.PEEK,
         this.name,
-        Integer.toString(count));
+        count);
     if (result.equals(ClientHelper.EMPTY_RESULT)) {
       return new ArrayList<Job>();
     }
@@ -154,10 +154,10 @@ public class Queue {
 
   public List<Job> pop(final int count) throws IOException {
     final Object result = this.client.call(
-        LuaCommand.POP.toString(),
+        LuaCommand.POP,
         this.name,
         this.client.workerName(),
-        Integer.toString(count));
+        count);
 
     if (result.equals(ClientHelper.EMPTY_RESULT)) {
       return Collections.emptyList();
@@ -199,13 +199,13 @@ public class Queue {
 
   public void setMaxConcurrency(final int maxConcurrency) throws IOException {
     this.client.getConfig().put(
-        LuaConfigParameter.MAX_CONCURRENCY.toString(),
+        LuaConfigParameter.MAX_CONCURRENCY,
         maxConcurrency);
   }
 
   public void unpause() throws IOException {
     this.client.call(
-        LuaCommand.UNPAUSE.toString(),
+        LuaCommand.UNPAUSE,
         this.name);
   }
 }

--- a/qless-java/src/main/java/com/moz/qless/QueueJobs.java
+++ b/qless-java/src/main/java/com/moz/qless/QueueJobs.java
@@ -20,11 +20,11 @@ public class QueueJobs {
   @SuppressWarnings("unchecked")
   public List<String> running(final int offset, final int count) throws IOException {
     final Object result = this.client.call(
-        LuaCommand.JOBS.toString(),
-        LuaCommand.RUNNING.toString(),
+        LuaCommand.JOBS,
+        LuaCommand.RUNNING,
         this.name,
-        Integer.toString(offset),
-        Integer.toString(count));
+        offset,
+        count);
 
      return (List<String>) result;
   }
@@ -39,11 +39,11 @@ public class QueueJobs {
   @SuppressWarnings("unchecked")
   public List<String> stalled(final int offset, final int count) throws IOException {
     final Object result = this.client.call(
-        LuaCommand.JOBS.toString(),
-        LuaCommand.STALLED.toString(),
+        LuaCommand.JOBS,
+        LuaCommand.STALLED,
         this.name,
-        Integer.toString(offset),
-        Integer.toString(count));
+        offset,
+        count);
 
     return (List<String>) result;
   }
@@ -58,11 +58,11 @@ public class QueueJobs {
   @SuppressWarnings("unchecked")
   public List<String> scheduled(final int offset, final int count) throws IOException {
     final Object result = this.client.call(
-        LuaCommand.JOBS.toString(),
-        LuaCommand.SCHEDULED.toString(),
+        LuaCommand.JOBS,
+        LuaCommand.SCHEDULED,
         this.name,
-        Integer.toString(offset),
-        Integer.toString(count));
+        offset,
+        count);
 
     return (List<String>) result;
   }
@@ -77,11 +77,11 @@ public class QueueJobs {
   @SuppressWarnings("unchecked")
   public List<String> depends(final int offset, final int count) throws IOException {
     final Object result = this.client.call(
-        LuaCommand.JOBS.toString(),
-        LuaCommand.DEPENDS.toString(),
+        LuaCommand.JOBS,
+        LuaCommand.DEPENDS,
         this.name,
-        Integer.toString(offset),
-        Integer.toString(count));
+        offset,
+        count);
 
     return (List<String>) result;
   }
@@ -96,11 +96,11 @@ public class QueueJobs {
   @SuppressWarnings("unchecked")
   public List<String> recurring(final int offset, final int count) throws IOException {
     final Object result = this.client.call(
-        LuaCommand.JOBS.toString(),
-        LuaCommand.RECURRING.toString(),
+        LuaCommand.JOBS,
+        LuaCommand.RECURRING,
         this.name,
-        Integer.toString(offset),
-        Integer.toString(count));
+        offset,
+        count);
 
     return (List<String>) result;
   }

--- a/qless-java/src/main/java/com/moz/qless/RecurringJob.java
+++ b/qless-java/src/main/java/com/moz/qless/RecurringJob.java
@@ -39,10 +39,10 @@ public class RecurringJob extends Job {
 
   public void backlog(final int backlog) throws IOException {
     this.client.call(
-        LuaCommand.RECUR_UPDATE.toString(),
+        LuaCommand.RECUR_UPDATE,
         this.jid,
-        LuaConfigParameter.BACKLOG.toString(),
-        Integer.toString(backlog));
+        LuaConfigParameter.BACKLOG,
+        backlog);
 
     this.backlog = backlog;
   }
@@ -50,7 +50,7 @@ public class RecurringJob extends Job {
   @Override
   public void cancel() throws IOException {
       this.client.call(
-          LuaCommand.UNRECUR.toString(),
+          LuaCommand.UNRECUR,
           this.jid);
   }
 
@@ -60,9 +60,9 @@ public class RecurringJob extends Job {
 
   public void data(final Map<String, Object> data) throws IOException {
       this.client.call(
-          LuaCommand.RECUR_UPDATE.toString(),
+          LuaCommand.RECUR_UPDATE,
           this.jid,
-          LuaConfigParameter.DATA.toString(),
+          LuaConfigParameter.DATA,
           JsonUtils.stringify(data));
 
       this.data = data;
@@ -96,9 +96,9 @@ public class RecurringJob extends Job {
 
   public void klass(final String klass) throws IOException {
       this.client.call(
-          LuaCommand.RECUR_UPDATE.toString(),
+          LuaCommand.RECUR_UPDATE,
           this.jid,
-          LuaConfigParameter.KLASS.toString(),
+          LuaConfigParameter.KLASS,
           klass);
 
       this.klass = klass;
@@ -124,9 +124,9 @@ public class RecurringJob extends Job {
     this.queue = null;
 
     final Object result = this.client.call(
-        LuaCommand.RECUR_UPDATE.toString(),
+        LuaCommand.RECUR_UPDATE,
         this.jid,
-        LuaConfigParameter.QUEUE.toString(),
+        LuaConfigParameter.QUEUE,
         queueName);
 
     return result.toString();
@@ -139,10 +139,10 @@ public class RecurringJob extends Job {
   @Override
   public void priority(final int priority) throws IOException {
       this.client.call(
-          LuaCommand.RECUR_UPDATE.toString(),
+          LuaCommand.RECUR_UPDATE,
           this.jid,
-          LuaConfigParameter.PRIORITY.toString(),
-          Integer.toString(priority));
+          LuaConfigParameter.PRIORITY,
+          priority);
 
       this.priority = priority;
   }
@@ -159,10 +159,10 @@ public class RecurringJob extends Job {
 
   public void retries(final int retries) throws IOException {
       this.client.call(
-          LuaCommand.RECUR_UPDATE.toString(),
+          LuaCommand.RECUR_UPDATE,
           this.jid,
-          LuaConfigParameter.RETRIES.toString(),
-          Integer.toString(retries));
+          LuaConfigParameter.RETRIES,
+          retries);
 
       this.retries = retries;
   }
@@ -175,7 +175,7 @@ public class RecurringJob extends Job {
       Collections.addAll(args, tags);
 
       this.client.call(
-          LuaCommand.RECUR_TAG.toString(),
+          LuaCommand.RECUR_TAG,
           args);
   }
 
@@ -187,7 +187,7 @@ public class RecurringJob extends Job {
       Collections.addAll(args, tags);
 
       this.client.call(
-          LuaCommand.RECUR_UNTAG.toString(),
+          LuaCommand.RECUR_UNTAG,
           args);
   }
 }

--- a/qless-java/src/main/java/com/moz/qless/client/ClientHelper.java
+++ b/qless-java/src/main/java/com/moz/qless/client/ClientHelper.java
@@ -7,22 +7,21 @@ import java.util.UUID;
 
 public class ClientHelper {
   public static final String EMPTY_RESULT = "{}";
-  public static final String ZERO_VALUE = "0";
 
-  public static final String DEFAULT_BACKLOG = ClientHelper.ZERO_VALUE;
-  public static final String DEFAULT_DELAY = ClientHelper.ZERO_VALUE;
   public static final String DEFAULT_HOSTNAME = "localhost";
-  public static final String DEFAULT_OFFSET = ClientHelper.ZERO_VALUE;
-  public static final String DEFAULT_PRIORITY = ClientHelper.ZERO_VALUE;
-  public static final String DEFAULT_RETRIES = "5";
-  public static final int DEFAULT_INTERVAL = 60;
-  public static final int DEFAULT_HEARTBEAT = 60;
   public static final String DEFAULT_APPLICATION = "qless";
-  public static final int DEFAULT_GRACE_PERIOD = 10;
-  public static final int DEFAULT_JOBS_HISTORY = 604800;
-  public static final int DEFAULT_STATS_HISTORY = 30;
-  public static final int DEFAULT_HISTOGRAM_HISTORY = 7;
-  public static final int DEFAULT_JOBS_HISTORY_COUNT = 50000;
+  public static final Integer DEFAULT_BACKLOG = 0;
+  public static final Integer DEFAULT_DELAY = 0;
+  public static final Integer DEFAULT_OFFSET = 0;
+  public static final Integer DEFAULT_PRIORITY = 0;
+  public static final Integer DEFAULT_RETRIES = 5;
+  public static final Integer DEFAULT_INTERVAL = 60;
+  public static final Integer DEFAULT_HEARTBEAT = 60;
+  public static final Integer DEFAULT_GRACE_PERIOD = 10;
+  public static final Integer DEFAULT_JOBS_HISTORY = 604800;
+  public static final Integer DEFAULT_STATS_HISTORY = 30;
+  public static final Integer DEFAULT_HISTOGRAM_HISTORY = 7;
+  public static final Integer DEFAULT_JOBS_HISTORY_COUNT = 50000;
 
   public static final String DEFAULT_JOB_METHOD = "process";
 

--- a/qless-java/src/main/java/com/moz/qless/client/Jobs.java
+++ b/qless-java/src/main/java/com/moz/qless/client/Jobs.java
@@ -35,17 +35,17 @@ public class Jobs {
   @SuppressWarnings("unchecked")
   public List<String> complete(final int offset, final int count) throws IOException {
     final Object result = this.client.call(
-        LuaCommand.JOBS.toString(),
-        LuaCommand.COMPLETE.toString(),
-        Integer.toString(offset),
-        Integer.toString(count));
+        LuaCommand.JOBS,
+        LuaCommand.COMPLETE,
+        offset,
+        count);
 
     return (List<String>) result;
   }
 
   public Map<String, Long> failed() throws IOException {
     final Object result = this.client.call(
-        LuaCommand.FAILED.toString());
+        LuaCommand.FAILED);
 
     final JavaType javaType = new ObjectMapper().getTypeFactory().constructMapType(
         HashMap.class, String.class, Long.class);
@@ -64,10 +64,10 @@ public class Jobs {
   public List<String> failed(final String group, final int start, final int limit)
       throws IOException {
     final Object result = this.client.call(
-	    LuaCommand.FAILED.toString(),
+	    LuaCommand.FAILED,
 	    group,
-      Integer.toString(start),
-      Integer.toString(limit));
+      start,
+      limit);
 
     final ObjectMapper mapper = new ObjectMapper();
     final JsonNode resultObj = mapper.readTree(result.toString());
@@ -82,7 +82,7 @@ public class Jobs {
    */
   public List<Job> get(final List<String> jids) throws IOException {
     final Object result = this.client.call(
-        LuaCommand.MULTIGET.toString(),
+        LuaCommand.MULTIGET,
         jids);
 
     final InjectableValues inject = new InjectableValues.Std().addValue(
@@ -107,12 +107,12 @@ public class Jobs {
   public Job get(final String jid) throws IOException {
     Class<? extends Job> klass = Job.class;
     Object result = this.client.call(
-	    LuaCommand.GET.toString(),
+	    LuaCommand.GET,
 	    jid);
 
     if (null == result) {
       result = this.client.call(
-	      LuaCommand.RECUR_GET.toString(),
+	      LuaCommand.RECUR_GET,
 	      jid);
       if (null == result) {
         return null;
@@ -137,11 +137,11 @@ public class Jobs {
   public List<String> tagged(final String tag, final int offset, final int count)
       throws IOException {
     final Object result = this.client.call(
-	    LuaCommand.TAG.toString(),
-      LuaCommand.GET.toString(),
+	    LuaCommand.TAG,
+      LuaCommand.GET,
       tag,
-      Integer.toString(offset),
-      Integer.toString(count));
+      offset,
+      count);
 
     final ObjectMapper mapper = new ObjectMapper();
     final JsonNode resultObj = mapper.readTree(result.toString());
@@ -156,7 +156,7 @@ public class Jobs {
    */
   public List<Job> tracked() throws IOException {
     final Object result = this.client.call(
-        LuaCommand.TRACK.toString());
+        LuaCommand.TRACK);
 
     final ObjectMapper mapper = new ObjectMapper();
     final JsonNode resultObj = mapper.readTree(result.toString());

--- a/qless-java/src/main/java/com/moz/qless/client/Queues.java
+++ b/qless-java/src/main/java/com/moz/qless/client/Queues.java
@@ -22,7 +22,7 @@ public class Queues {
 
   public List<QueueCounts> counts() throws IOException {
     final Object result = this.client.call(
-        LuaCommand.QUEUES.toString());
+        LuaCommand.QUEUES);
 
     final JavaType javaType = new ObjectMapper().getTypeFactory()
         .constructCollectionType(ArrayList.class, QueueCounts.class);

--- a/qless-java/src/main/java/com/moz/qless/job/JobPutter.java
+++ b/qless-java/src/main/java/com/moz/qless/job/JobPutter.java
@@ -18,9 +18,9 @@ public final class JobPutter {
 
   private final Map<String, Object> data;
   private final String jid;
-  private final String priority;
-  private final String delay;
-  private final String retries;
+  private final int priority;
+  private final int delay;
+  private final int retries;
   private final List<String> depends;
   private final List<String> tags;
 
@@ -63,9 +63,9 @@ public final class JobPutter {
 
     private Map<String, Object> data = new HashMap<>();
     private String jid = ClientHelper.generateJid();
-    private String priority = ClientHelper.DEFAULT_PRIORITY;
-    private String delay = ClientHelper.DEFAULT_DELAY;
-    private String retries = ClientHelper.DEFAULT_RETRIES;
+    private int priority = ClientHelper.DEFAULT_PRIORITY;
+    private int delay = ClientHelper.DEFAULT_DELAY;
+    private int retries = ClientHelper.DEFAULT_RETRIES;
     private List<String> depends = new ArrayList<>();
     private List<String> tags = new ArrayList<>();
 
@@ -79,12 +79,12 @@ public final class JobPutter {
       return this;
     }
 
-    public Builder priority(final String priority) {
+    public Builder priority(final int priority) {
       this.priority = priority;
       return this;
     }
 
-    public Builder delay(final String delay) {
+    public Builder delay(final int delay) {
       this.delay = delay;
       return this;
     }
@@ -99,7 +99,7 @@ public final class JobPutter {
       return this;
     }
 
-    public Builder retries(final String retires) {
+    public Builder retries(final int retires) {
       this.retries = retires;
       return this;
     }

--- a/qless-java/src/main/java/com/moz/qless/job/JobPutter.java
+++ b/qless-java/src/main/java/com/moz/qless/job/JobPutter.java
@@ -94,6 +94,11 @@ public final class JobPutter {
       return this;
     }
 
+    public Builder data(final String key, final Object value) {
+      this.data.put(key, value);
+      return this;
+    }
+
     public Builder retries(final String retires) {
       this.retries = retires;
       return this;

--- a/qless-java/src/main/java/com/moz/qless/job/JobPutter.java
+++ b/qless-java/src/main/java/com/moz/qless/job/JobPutter.java
@@ -38,7 +38,7 @@ public final class JobPutter {
 
   public String put(final String klassName) throws IOException {
     final Object result = this.client.call(
-        LuaCommand.PUT.toString(),
+        LuaCommand.PUT,
         this.client.workerName(),
         this.queueName,
         this.jid,

--- a/qless-java/src/main/java/com/moz/qless/job/RecurJobPutter.java
+++ b/qless-java/src/main/java/com/moz/qless/job/RecurJobPutter.java
@@ -20,10 +20,10 @@ public final class RecurJobPutter {
   private final Map<String, Object> data;
   private final String jid;
   private final int interval;
-  private final String priority;
-  private final String offset;
-  private final String retries;
-  private final String backlog;
+  private final int priority;
+  private final int offset;
+  private final int retries;
+  private final int backlog;
   private final List<String> depends;
   private final List<String> tags;
 
@@ -69,11 +69,11 @@ public final class RecurJobPutter {
 
     private Map<String, Object> data = new HashMap<>();
     private String jid = ClientHelper.generateJid();
-    private String priority = ClientHelper.DEFAULT_PRIORITY;
+    private int priority = ClientHelper.DEFAULT_PRIORITY;
     private int interval = ClientHelper.DEFAULT_INTERVAL;
-    private String offset = ClientHelper.DEFAULT_OFFSET;
-    private String retries = ClientHelper.DEFAULT_RETRIES;
-    private String backlog = ClientHelper.DEFAULT_BACKLOG;
+    private int offset = ClientHelper.DEFAULT_OFFSET;
+    private int retries = ClientHelper.DEFAULT_RETRIES;
+    private int backlog = ClientHelper.DEFAULT_BACKLOG;
     private List<String> depends = new ArrayList<>();
     private List<String> tags = new ArrayList<>();
 
@@ -87,12 +87,12 @@ public final class RecurJobPutter {
       return this;
     }
 
-    public Builder priority(final String priority) {
+    public Builder priority(final int priority) {
       this.priority = priority;
       return this;
     }
 
-    public Builder offset(final String offset) {
+    public Builder offset(final int offset) {
       this.offset = offset;
       return this;
     }
@@ -107,12 +107,12 @@ public final class RecurJobPutter {
       return this;
     }
 
-    public Builder retries(final String retires) {
+    public Builder retries(final int retires) {
       this.retries = retires;
       return this;
     }
 
-    public Builder backlog(final String backlog) {
+    public Builder backlog(final int backlog) {
       this.backlog = backlog;
       return this;
     }

--- a/qless-java/src/main/java/com/moz/qless/job/RecurJobPutter.java
+++ b/qless-java/src/main/java/com/moz/qless/job/RecurJobPutter.java
@@ -102,6 +102,11 @@ public final class RecurJobPutter {
       return this;
     }
 
+    public Builder data(final String key, final Object value) {
+      this.data.put(key, value);
+      return this;
+    }
+
     public Builder retries(final String retires) {
       this.retries = retires;
       return this;

--- a/qless-java/src/main/java/com/moz/qless/job/RecurJobPutter.java
+++ b/qless-java/src/main/java/com/moz/qless/job/RecurJobPutter.java
@@ -43,21 +43,21 @@ public final class RecurJobPutter {
 
   public String recur(final String klassName) throws IOException {
     final Object result = this.client.call(
-        LuaCommand.RECUR.toString(),
+        LuaCommand.RECUR,
         this.queueName,
         this.jid,
         klassName,
         JsonUtils.stringify(this.data),
-        LuaConfigParameter.INTERVAL.toString(),
+        LuaConfigParameter.INTERVAL,
         String.valueOf(this.interval),
         this.offset,
-        LuaConfigParameter.PRIORITY.toString(),
+        LuaConfigParameter.PRIORITY,
         this.priority,
-        LuaConfigParameter.TAGS.toString(),
+        LuaConfigParameter.TAGS,
         JsonUtils.stringify(this.tags),
-        LuaConfigParameter.RETRIES.toString(),
+        LuaConfigParameter.RETRIES,
         this.retries,
-        LuaConfigParameter.BACKLOG.toString(),
+        LuaConfigParameter.BACKLOG,
         this.backlog);
 
     return result.toString();

--- a/qless-java/src/test/java/com/moz/qless/IntegrationTestJob.java
+++ b/qless-java/src/test/java/com/moz/qless/IntegrationTestJob.java
@@ -47,4 +47,8 @@ public class IntegrationTestJob {
     IntegrationTestJob.runningHistory.add(result);
     System.out.println(result);
   }
+
+  public static void testMessagelessException(final Job job) {
+    throw new RuntimeException();
+  }
 }

--- a/qless-java/src/test/java/com/moz/qless/JobTest.java
+++ b/qless-java/src/test/java/com/moz/qless/JobTest.java
@@ -360,14 +360,14 @@ public class JobTest extends IntegrationTest {
         contains("com.moz.qless.IntegrationTestJob.test"));
   }
 
-  @Test(expected = QlessException.class)
   public void runJobMissingKlass() throws IOException {
-    this.queue
+    final String jid = this.queue
         .newJobPutter()
         .build()
         .put(JobTest.DEFAULT_NAME);
 
     this.queue.pop().process();
+    assertThat(this.client.getJobs().get(jid).getState(), equalTo("failed"));
   }
 
   @Test
@@ -378,19 +378,18 @@ public class JobTest extends IntegrationTest {
         .put("com.moz.qless.IntegrationTestJob");
 
     queue.pop().process();
-
     assertThat(IntegrationTestJob.runningHistory,
         contains("com.moz.qless.IntegrationTestJob." + ClientHelper.DEFAULT_JOB_METHOD));
   }
 
-  @Test(expected = QlessException.class)
   public void runJobMissingMethod() throws IOException {
     final Queue queue = new Queue(this.client, "none");
-    queue.newJobPutter()
+    final String jid = queue.newJobPutter()
         .build()
         .put("com.moz.qless.EmptyJob");
 
     queue.pop().process();
+    assertThat(this.client.getJobs().get(jid).getState(), equalTo("failed"));
   }
 
   @Test

--- a/qless-java/src/test/java/com/moz/qless/JobTest.java
+++ b/qless-java/src/test/java/com/moz/qless/JobTest.java
@@ -174,6 +174,18 @@ public class JobTest extends IntegrationTest {
   }
 
   @Test
+  public void addData() throws IOException {
+    final String jid = this.queue
+      .newJobPutter()
+      .data("hello", "world")
+      .build()
+      .put(JobTest.DEFAULT_NAME);
+
+    final Job job = this.client.getJobs().get(jid);
+    assertThat((String) job.getDataField("hello"), equalTo("world"));
+  }
+
+  @Test
   public void move() throws IOException {
     final Map<String, Object> data = new HashMap<>();
     data.put("key1", "value1");

--- a/qless-java/src/test/java/com/moz/qless/JobTest.java
+++ b/qless-java/src/test/java/com/moz/qless/JobTest.java
@@ -24,7 +24,7 @@ public class JobTest extends IntegrationTest {
     this.queue
         .newJobPutter()
         .jid(jid)
-        .priority("0")
+        .priority(0)
         .build()
         .put(JobTest.DEFAULT_NAME);
 

--- a/qless-java/src/test/java/com/moz/qless/JobTest.java
+++ b/qless-java/src/test/java/com/moz/qless/JobTest.java
@@ -149,7 +149,7 @@ public class JobTest extends IntegrationTest {
         .build()
         .put(JobTest.DEFAULT_NAME);
 
-    assertThat((String) this.client.getJobs().get(jid).getDataField("foo"),
+    assertThat(this.client.getJobs().get(jid).<String>getDataField("foo"),
         equalTo("bar"));
   }
 
@@ -165,11 +165,11 @@ public class JobTest extends IntegrationTest {
         .put(JobTest.DEFAULT_NAME);
 
     final Job job = this.client.getJobs().get(jid);
-    assertThat((String) job.getDataField(JobTest.DEFAULT_NAME),
+    assertThat(job.<String>getDataField(JobTest.DEFAULT_NAME),
         equalTo("bar1"));
 
     job.setDataField(JobTest.DEFAULT_NAME, "bar2");
-    assertThat((String) job.getDataField(JobTest.DEFAULT_NAME),
+    assertThat(job.<String>getDataField(JobTest.DEFAULT_NAME),
         equalTo("bar2"));
   }
 
@@ -182,7 +182,7 @@ public class JobTest extends IntegrationTest {
       .put(JobTest.DEFAULT_NAME);
 
     final Job job = this.client.getJobs().get(jid);
-    assertThat((String) job.getDataField("hello"), equalTo("world"));
+    assertThat(job.<String>getDataField("hello"), equalTo("world"));
   }
 
   @Test

--- a/qless-java/src/test/java/com/moz/qless/JobTest.java
+++ b/qless-java/src/test/java/com/moz/qless/JobTest.java
@@ -140,17 +140,19 @@ public class JobTest extends IntegrationTest {
 
   @Test
   public void getDataField() throws IOException {
-    final Map<String, Object> data = new HashMap<>();
-    data.put("foo", "bar");
+    final String key = "foo";
+    final String value = "bar";
 
     final String jid = this.queue
         .newJobPutter()
-        .data(data)
+        .data(key, value)
         .build()
         .put(JobTest.DEFAULT_NAME);
 
-    assertThat(this.client.getJobs().get(jid).<String>getDataField("foo"),
-        equalTo("bar"));
+    assertThat(this.client.getJobs().get(jid).<String>getDataField(key),
+        equalTo(value));
+    assertThat(this.client.getJobs().get(jid).getDataField(String.class, key),
+        equalTo(value));
   }
 
   @Test

--- a/qless-java/src/test/java/com/moz/qless/JobTest.java
+++ b/qless-java/src/test/java/com/moz/qless/JobTest.java
@@ -337,6 +337,16 @@ public class JobTest extends IntegrationTest {
   }
 
   @Test
+  public void failWithoutErrorMessage() throws IOException {
+    final Queue queue = this.client.getQueue("testMessagelessException");
+    final String jid = queue.newJobPutter()
+        .build()
+        .put("com.moz.qless.IntegrationTestJob");
+    queue.pop().process();
+    assertThat(this.client.getJobs().get(jid).getState(), equalTo("failed"));
+  }
+
+  @Test
   public void runJobBasic() throws IOException {
     final Queue queue = new Queue(this.client, "test");
 

--- a/qless-java/src/test/java/com/moz/qless/QueueTest.java
+++ b/qless-java/src/test/java/com/moz/qless/QueueTest.java
@@ -27,7 +27,7 @@ public class QueueTest extends IntegrationTest {
         .newJobPutter()
         .data(data)
         .jid(expectedJid)
-        .retries("3")
+        .retries(3)
         .tags("tag1", "tag2")
         .build()
         .put(QueueTest.DEFAULT_NAME);

--- a/qless-java/src/test/java/com/moz/qless/RecurringJobTest.java
+++ b/qless-java/src/test/java/com/moz/qless/RecurringJobTest.java
@@ -31,9 +31,9 @@ public class RecurringJobTest extends IntegrationTest {
     assertThat(job.getQueueName(),
         equalTo(RecurringJobTest.DEFAULT_NAME));
     assertThat(job.getPriority(),
-        equalTo(Integer.parseInt(ClientHelper.DEFAULT_PRIORITY)));
+        equalTo(ClientHelper.DEFAULT_PRIORITY));
     assertThat(job.getRetries(),
-        equalTo(Integer.parseInt(ClientHelper.DEFAULT_RETRIES)));
+        equalTo(ClientHelper.DEFAULT_RETRIES));
   }
 
   @Test
@@ -44,7 +44,7 @@ public class RecurringJobTest extends IntegrationTest {
         .newRecurJobPutter()
         .interval(60)
         .jid(jid)
-        .priority("0")
+        .priority(0)
         .build()
         .recur(RecurringJobTest.DEFAULT_NAME);
 
@@ -64,7 +64,7 @@ public class RecurringJobTest extends IntegrationTest {
         .newRecurJobPutter()
         .interval(60)
         .jid(jid)
-        .retries("2")
+        .retries(2)
         .build()
         .recur(RecurringJobTest.DEFAULT_NAME);
 

--- a/qless-java/src/test/java/com/moz/qless/RecurringJobTest.java
+++ b/qless-java/src/test/java/com/moz/qless/RecurringJobTest.java
@@ -126,7 +126,7 @@ public class RecurringJobTest extends IntegrationTest {
       .recur(RecurringJobTest.DEFAULT_NAME);
 
     final Job job = this.client.getJobs().get(jid);
-    assertThat((String) job.getDataField("hello"), equalTo("world"));
+    assertThat(job.<String>getDataField("hello"), equalTo("world"));
   }
 
   @Test

--- a/qless-java/src/test/java/com/moz/qless/RecurringJobTest.java
+++ b/qless-java/src/test/java/com/moz/qless/RecurringJobTest.java
@@ -118,6 +118,18 @@ public class RecurringJobTest extends IntegrationTest {
   }
 
   @Test
+  public void addData() throws IOException {
+    final String jid = this.queue
+      .newRecurJobPutter()
+      .data("hello", "world")
+      .build()
+      .recur(RecurringJobTest.DEFAULT_NAME);
+
+    final Job job = this.client.getJobs().get(jid);
+    assertThat((String) job.getDataField("hello"), equalTo("world"));
+  }
+
+  @Test
   public void setKlass() throws IOException {
     final String jid = this.queue
         .newRecurJobPutter()


### PR DESCRIPTION
Through the exercise of using this library, found some usability tweaks. Some of the easier ones are covered in this PR.

1) When supplying job data, it can be a little awkward to create a new `HashMap<String, Object>`, fill it in and then set it. Witness:

```java
// Old way (still supported)
final Map<String, Object> data = new HashMap<>();
data.put("hello", "world");
data.put("foo", "bar");
client.getQueue("queueName").newJobPutter()
    .data(data)
    .build()
    .put(...);

// New way:
client.getQueue("queueName").newJobPutter()
    .data("hello", "world")
    .data("foo", "bar")
    .build()
    .put(...);
```

2) Generic-ify `Job.getDataField` to avoid callers having to cast the returned object themselves. It's less an issue of usability, so much as containing the `ClassCastException` better.

3) Generalizing the `Client.call` signature to remove a lot of `.toString` calls when invoking the method.

4) Some integer fields were treated as strings for convenience, especially in the context of `JobPutter` and `RecurJobPutter`. But with the generalized call signature, they're more easily kept as ints. Witness:

```java
// Old way (no longer supported)
client.getQueue("queueName").newJobPutter()
    .priority("5")
    .build()
    .put(...);

// New way
client.getQueue("queueName").newJobPutter()
    .priority(5)
    .build()
    .put(...);
```