### PR TITLE
Add client getters to Job, Queue

### DIFF
--- a/qless-java/src/main/java/com/moz/qless/Job.java
+++ b/qless-java/src/main/java/com/moz/qless/Job.java
@@ -98,6 +98,10 @@ public class Job {
     this.client = client;
   }
 
+  public Client getClient() {
+    return client;
+  }
+
   public void cancel() throws IOException {
     this.client.call(
         LuaCommand.CANCEL,

--- a/qless-java/src/main/java/com/moz/qless/Queue.java
+++ b/qless-java/src/main/java/com/moz/qless/Queue.java
@@ -30,6 +30,10 @@ public final class Queue {
     this.name = name;
   }
 
+  public Client getClient() {
+    return client;
+  }
+
   public QueueCounts getCounts() throws IOException {
     final Object result = this.client.call(
         LuaCommand.QUEUES,


### PR DESCRIPTION
It's important to be able to reference the client associated with a given job. Consider the case where I want to put jobs in another queue as part of processing a given job:

```java
public void process(final Job job) throws IOException {
  // This doesn't work -- can't get job's client
  final Queue queue = job.getClient().getQueue("otherQueue");

  // We can't go the roundabout way, either
  final Queue queue = job.getQueue().getClient.getQueue("otherQueue");
}
```

This adds `getClient` to just about everything I could think of that's not actually only practically accessible through a client. For instance, `Config` doesn't necessarily need to provide access to its `Client`, since it's accessed via `Client#getConfig`.