### PR TITLE
Fix missing plugin version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
This is the documented version to use according to here:

http://maven.apache.org/plugins/maven-javadoc-plugin/usage.html

And it is the current most recent release according to maven central:

http://mvnrepository.com/artifact/org.apache.maven.plugins/maven-javadoc-plugin

Resolves #24.