### PR TITLE
Enable and error on warnings and fix the few warnings that were discovered

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
+          <compilerArgs>
+            <arg>-Werror</arg>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/moz/qless/Client.java
+++ b/src/main/java/com/moz/qless/Client.java
@@ -70,7 +70,8 @@ public class Client {
 
     for (final Object arg : args) {
       if (arg instanceof List) {
-        for (final Object subArg : (List<Object>) arg) {
+        final List<?> subArgs = (List<?>) arg;
+        for (final Object subArg : subArgs) {
           argsList.add(subArg.toString());
         }
       } else {

--- a/src/main/java/com/moz/qless/Job.java
+++ b/src/main/java/com/moz/qless/Job.java
@@ -164,8 +164,7 @@ public class Job {
       args.add(jid);
     }
 
-    final String[] array = new String[args.size()];
-    args.toArray(array);
+    final Object[] array = args.toArray(new String[args.size()]);
 
     this.client.call(
         LuaCommand.DEPENDS,
@@ -487,8 +486,7 @@ public class Job {
 
     Collections.addAll(args, jids);
 
-    final String[] array = new String[args.size()];
-    args.toArray(array);
+    final Object[] array = args.toArray(new String[args.size()]);
 
     this.client.call(
         LuaCommand.DEPENDS,


### PR DESCRIPTION
There were 3 warnings that were discovered after fully enabling them in the build.

There were two examples of ambiguous varargs calls and one example of an unchecked warning.