### PR TITLE
Get/Set Queue Max Concurrency

### DIFF
--- a/src/main/java/com/moz/qless/Queue.java
+++ b/src/main/java/com/moz/qless/Queue.java
@@ -46,6 +46,10 @@ public final class Queue {
     return this.name + "-" + LuaConfigParameter.HEARTBEAT;
   }
 
+  private String getMaxConcurrencyConfigName() {
+    return this.name + "-" + LuaConfigParameter.MAX_CONCURRENCY;
+  }
+
   public int getHeartbeat() throws IOException {
     Object heartbeat = this.client.getConfig()
         .get(this.getHeartbeatConfigName());
@@ -57,10 +61,13 @@ public final class Queue {
     return Integer.parseInt(heartbeat.toString());
   }
 
+  /**
+   * Returns the max concurrency for the queue, or -1 if there is none.
+   */
   public int getMaxConcurrency() throws IOException {
-    return Integer.parseInt(
-        this.client.getConfig().get(LuaConfigParameter.MAX_CONCURRENCY)
-        .toString());
+    final String concurrency =
+      (String) this.client.getConfig().get(getMaxConcurrencyConfigName());
+    return concurrency == null ? -1 : Integer.parseInt(concurrency);
   }
 
   public String getName() {
@@ -180,10 +187,15 @@ public final class Queue {
         heartbeat);
   }
 
+  /**
+   * Setting to a negative number removes any max concurrency restriction.
+   */
   public void setMaxConcurrency(final int maxConcurrency) throws IOException {
-    this.client.getConfig().put(
-        LuaConfigParameter.MAX_CONCURRENCY,
-        maxConcurrency);
+    if (maxConcurrency < 0) {
+      this.client.getConfig().pop(getMaxConcurrencyConfigName());
+    } else {
+      this.client.getConfig().put(getMaxConcurrencyConfigName(), maxConcurrency);
+    }
   }
 
   public void unpause() throws IOException {

--- a/src/test/java/com/moz/qless/QueueTest.java
+++ b/src/test/java/com/moz/qless/QueueTest.java
@@ -183,4 +183,31 @@ public class QueueTest extends IntegrationTest {
     assertThat(this.queue.length(),
         equalTo(1));
   }
+
+  @Test
+  public void setMaxConcurrency() throws IOException {
+    this.queue.setMaxConcurrency(10);
+    assertThat(
+      Integer.parseInt(
+        (String) this.client.getConfig().get(this.queue.getName() + "-max-concurrency")),
+      equalTo(10));
+  }
+
+  @Test
+  public void getMaxConcurrency() throws IOException {
+    this.client.getConfig().put(this.queue.getName() + "-max-concurrency", 10);
+    assertThat(this.queue.getMaxConcurrency(), equalTo(10));
+  }
+
+  @Test
+  public void getMaxConcurrencyNotSet() throws IOException {
+    assertThat(this.queue.getMaxConcurrency(), equalTo(-1));
+  }
+
+  @Test
+  public void unsetMaxConcurrency() throws IOException {
+    this.queue.setMaxConcurrency(10);
+    this.queue.setMaxConcurrency(-1);
+    assertThat(this.queue.getMaxConcurrency(), equalTo(-1));
+  }
 }


### PR DESCRIPTION
There was a bug where attempting to set a queue's max concurrency was setting the `max-concurrency` config, not `<queue-name>-max-concurrency`.