### PR TITLE
Fix task failure error messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.moz.qless</groupId>
   <artifactId>qless-java</artifactId>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/src/test/java/com/moz/qless/IntegrationTest.java
+++ b/src/test/java/com/moz/qless/IntegrationTest.java
@@ -14,6 +14,8 @@ public class IntegrationTest {
   protected Client client;
   protected Queue queue;
   protected static final String DEFAULT_NAME = "foo";
+  protected static final String DEFAULT_JOB_CLASS_NAME =
+    IntegrationTestJob.class.getName();
 
   @Before
   public void setupQueues() throws IOException {

--- a/src/test/java/com/moz/qless/IntegrationTestJob.java
+++ b/src/test/java/com/moz/qless/IntegrationTestJob.java
@@ -51,4 +51,8 @@ public class IntegrationTestJob {
   public static void testMessagelessException(final Job job) {
     throw new RuntimeException();
   }
+
+  public static void testAlwaysFails(final Job job) {
+    throw new UnsupportedOperationException("This always fails");
+  }
 }

--- a/src/test/java/com/moz/qless/JobTest.java
+++ b/src/test/java/com/moz/qless/JobTest.java
@@ -310,6 +310,23 @@ public class JobTest extends IntegrationTest {
   }
 
   @Test
+  public void runJobThatFails() throws IOException {
+    final Queue queue = new Queue(this.client, "testAlwaysFails");
+    final String jid = queue.put(
+      jobSpec(DEFAULT_JOB_CLASS_NAME));
+
+    queue.pop().process();
+
+    final Job job = this.client.getJobs().get(jid);
+    assertThat(job.getState(), equalTo(JobStatus.FAILED.toString()));
+    assertThat(
+      job.getFailure(),
+      hasEntry(
+        "group",
+        (Object) "testAlwaysFails-java.lang.UnsupportedOperationException"));
+  }
+
+  @Test
   public void history() throws IOException {
     final String jid = this.queue.put(jobSpec());
 

--- a/src/test/java/com/moz/qless/JobTest.java
+++ b/src/test/java/com/moz/qless/JobTest.java
@@ -259,7 +259,7 @@ public class JobTest extends IntegrationTest {
   @Test
   public void failWithoutErrorMessage() throws IOException {
     final Queue queue = this.client.getQueue("testMessagelessException");
-    final String jid = queue.put(jobSpec("com.moz.qless.IntegrationTestJob"));
+    final String jid = queue.put(jobSpec(DEFAULT_JOB_CLASS_NAME));
     queue.pop().process();
     assertThat(
       this.client.getJobs().get(jid).getState(),
@@ -270,7 +270,7 @@ public class JobTest extends IntegrationTest {
   public void runJobBasic() throws IOException {
     final Queue queue = new Queue(this.client, "test");
 
-    queue.put(jobSpec("com.moz.qless.IntegrationTestJob"));
+    queue.put(jobSpec(DEFAULT_JOB_CLASS_NAME));
 
     queue.pop().process();
 
@@ -291,12 +291,12 @@ public class JobTest extends IntegrationTest {
   @Test
   public void runJobDefaultMethod() throws IOException {
     final Queue queue = new Queue(this.client, "none");
-    queue.put(jobSpec("com.moz.qless.IntegrationTestJob"));
+    queue.put(jobSpec(DEFAULT_JOB_CLASS_NAME));
 
     queue.pop().process();
     assertThat(
       IntegrationTestJob.runningHistory,
-      contains("com.moz.qless.IntegrationTestJob." + ClientHelper.DEFAULT_JOB_METHOD));
+      contains(DEFAULT_JOB_CLASS_NAME + "." + ClientHelper.DEFAULT_JOB_METHOD));
   }
 
   public void runJobMissingMethod() throws IOException {


### PR DESCRIPTION
Change the error handling in `Job#fail` to include the original exception thrown by the job in the group name and the original exception stack trace in the message instead of `java.lang.reflect.InvocationTargetException` and its wrapped stack trace.