### PR TITLE
Upgrade jedis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>2.6.2</version>
+      <version>2.7.2</version>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>

--- a/src/main/java/com/moz/qless/Client.java
+++ b/src/main/java/com/moz/qless/Client.java
@@ -1,6 +1,7 @@
 package com.moz.qless;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -47,11 +48,15 @@ public class Client implements AutoCloseable {
   private static final List<String> KEYS_LIST = new ArrayList<>();
 
   public Client() {
-    this(new JedisPool(ClientHelper.DEFAULT_HOSTNAME));
+    this(ClientHelper.DEFAULT_URI);
   }
 
-  public Client(final String url) {
-    this(new JedisPool(url));
+  public Client(final String uri) {
+    this(URI.create(uri));
+  }
+
+  public Client(final URI uri) {
+    this(new JedisPool(uri));
   }
 
   /**

--- a/src/main/java/com/moz/qless/Events.java
+++ b/src/main/java/com/moz/qless/Events.java
@@ -53,7 +53,7 @@ public class Events implements AutoCloseable {
       // Restore the interrupted status
       Thread.currentThread().interrupt();
     }
-    this.jedisPool.returnResource(jedis);
+    jedis.close();
   }
 
   public void subscribe(final String... channels) {

--- a/src/main/java/com/moz/qless/Queue.java
+++ b/src/main/java/com/moz/qless/Queue.java
@@ -94,8 +94,7 @@ public final class Queue {
   }
 
   public int length() throws IOException {
-    final Jedis jedis = this.client.getJedisPool().getResource();
-    try {
+    try (final Jedis jedis = this.client.getJedisPool().getResource()) {
       final Transaction transaction = jedis.multi();
       transaction.zcard("ql:q:" + this.name + "-locks");
       transaction.zcard("ql:q:" + this.name + "-work");
@@ -107,8 +106,6 @@ public final class Queue {
       }
 
       return length;
-    } finally {
-      this.client.getJedisPool().returnResource(jedis);
     }
   }
 

--- a/src/main/java/com/moz/qless/client/ClientHelper.java
+++ b/src/main/java/com/moz/qless/client/ClientHelper.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 public class ClientHelper {
   public static final String EMPTY_RESULT = "{}";
 
-  public static final String DEFAULT_HOSTNAME = "localhost";
+  public static final String DEFAULT_URI = "redis://";
   public static final String DEFAULT_APPLICATION = "qless";
   public static final Integer DEFAULT_BACKLOG = 0;
   public static final Integer DEFAULT_DELAY = 0;
@@ -37,7 +37,7 @@ public class ClientHelper {
     try {
       return InetAddress.getLocalHost().getHostName();
     } catch (final UnknownHostException e) {
-      return ClientHelper.DEFAULT_HOSTNAME;
+      return "localhost";
     }
   }
 

--- a/src/main/java/com/moz/qless/lua/LuaScript.java
+++ b/src/main/java/com/moz/qless/lua/LuaScript.java
@@ -26,11 +26,8 @@ public class LuaScript {
 
   public Object call(final List<String> keys, final List<String> args)
       throws IOException {
-    final Jedis jedis = this.jedisPool.getResource();
-    try {
+    try (final Jedis jedis = this.jedisPool.getResource()) {
       return jedis.evalsha(this.calculateSha1(jedis), keys, args);
-    } finally {
-      this.jedisPool.returnResource(jedis);
     }
   }
 

--- a/src/test/java/com/moz/qless/IntegrationTest.java
+++ b/src/test/java/com/moz/qless/IntegrationTest.java
@@ -2,15 +2,13 @@ package com.moz.qless;
 
 import java.io.IOException;
 
-import com.moz.qless.client.ClientHelper;
-
 import org.junit.Before;
 
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
 public class IntegrationTest {
-  private final JedisPool jedisPool = new JedisPool(ClientHelper.DEFAULT_HOSTNAME);
+  private final JedisPool jedisPool = new JedisPool();
   protected Client client;
   protected Queue queue;
   protected static final String DEFAULT_NAME = "foo";

--- a/src/test/java/com/moz/qless/IntegrationTest.java
+++ b/src/test/java/com/moz/qless/IntegrationTest.java
@@ -33,11 +33,8 @@ public class IntegrationTest {
   }
 
   private Client create() {
-    final Jedis jedis = this.jedisPool.getResource();
-    try {
+    try (final Jedis jedis = this.jedisPool.getResource()) {
       jedis.flushDB();
-    } finally {
-      this.jedisPool.returnResource(jedis);
     }
 
     return new Client(this.jedisPool);


### PR DESCRIPTION
`returnResource` is now deprecated, and we can just use `close` directly, which means try-with-resources is the preferred usage.