### PR TITLE
Make IntegrationTestJob.runningHistory final.

### DIFF
--- a/src/test/java/com/moz/qless/IntegrationTest.java
+++ b/src/test/java/com/moz/qless/IntegrationTest.java
@@ -20,7 +20,7 @@ public class IntegrationTest {
   public void setupQueues() throws IOException {
     this.client = this.create();
     this.queue = new Queue(this.client, DEFAULT_NAME);
-    IntegrationTestJob.runningHistory.clear();
+    IntegrationTestJob.RUNNING_HISTORY.clear();
   }
 
   protected JobSpec jobSpec() {

--- a/src/test/java/com/moz/qless/IntegrationTestJob.java
+++ b/src/test/java/com/moz/qless/IntegrationTestJob.java
@@ -6,20 +6,20 @@ import java.util.List;
 import com.moz.qless.client.ClientHelper;
 
 public class IntegrationTestJob {
-  public static List<String> runningHistory = new ArrayList<>();
+  public static final List<String> RUNNING_HISTORY = new ArrayList<>();
   private static final String DELIMETER = ".";
 
   public static void process(final Job job) {
     final String result = job.getKlassName() + DELIMETER
         + ClientHelper.DEFAULT_JOB_METHOD;
-    runningHistory.add(result);
+    RUNNING_HISTORY.add(result);
     System.out.println(result);
   }
 
   public static void test(final Job job) {
     final String result = job.getKlassName() + DELIMETER + job.getQueueName();
 
-    runningHistory.add(result);
+    RUNNING_HISTORY.add(result);
     System.out.println(result);
   }
 
@@ -27,21 +27,21 @@ public class IntegrationTestJob {
     final String result = job.getKlassName()
         + DELIMETER + job.getQueueName();
 
-    runningHistory.add(result);
+    RUNNING_HISTORY.add(result);
     System.out.println(result);
   }
 
   public static void testB(final Job job) {
     final String result = job.getKlassName() + DELIMETER + job.getQueueName();
 
-    runningHistory.add(result);
+    RUNNING_HISTORY.add(result);
     System.out.println(result);
   }
 
   public static void testC(final Job job) {
     final String result = job.getKlassName() + DELIMETER + job.getQueueName();
 
-    runningHistory.add(result);
+    RUNNING_HISTORY.add(result);
     System.out.println(result);
   }
 

--- a/src/test/java/com/moz/qless/JobTest.java
+++ b/src/test/java/com/moz/qless/JobTest.java
@@ -274,7 +274,7 @@ public class JobTest extends IntegrationTest {
 
     queue.pop().process();
 
-    assertThat(IntegrationTestJob.runningHistory,
+    assertThat(IntegrationTestJob.RUNNING_HISTORY,
         contains("com.moz.qless.IntegrationTestJob.test"));
   }
 
@@ -295,7 +295,7 @@ public class JobTest extends IntegrationTest {
 
     queue.pop().process();
     assertThat(
-      IntegrationTestJob.runningHistory,
+      IntegrationTestJob.RUNNING_HISTORY,
       contains(DEFAULT_JOB_CLASS_NAME + "." + ClientHelper.DEFAULT_JOB_METHOD));
   }
 

--- a/src/test/java/com/moz/qless/SerialWorkerTest.java
+++ b/src/test/java/com/moz/qless/SerialWorkerTest.java
@@ -35,7 +35,7 @@ public class SerialWorkerTest extends IntegrationTest {
     final SerialWorker worker = new SerialWorker(
         Arrays.asList(DEFAULT_QUEUE_NAME),
         this.client, null, 10);
-    IntegrationTestJob.runningHistory.clear();
+    IntegrationTestJob.RUNNING_HISTORY.clear();
 
     final Thread signal = this.getWorkerThread(worker, 2);
 
@@ -56,14 +56,14 @@ public class SerialWorkerTest extends IntegrationTest {
     final SerialWorker worker = new SerialWorker(
         Arrays.asList(DEFAULT_QUEUE_NAME),
         this.client, null, 10);
-    IntegrationTestJob.runningHistory.clear();
+    IntegrationTestJob.RUNNING_HISTORY.clear();
 
     final Thread signal = this.getWorkerThread(worker, 2);
 
     signal.start();
     worker.run();
 
-    assertThat(IntegrationTestJob.runningHistory.get(0),
+    assertThat(IntegrationTestJob.RUNNING_HISTORY.get(0),
         equalTo(DEFAULT_JOB_NAME + ".test"));
   }
 
@@ -75,14 +75,14 @@ public class SerialWorkerTest extends IntegrationTest {
     final SerialWorker worker = new SerialWorker(
         Arrays.asList("foo"),
         this.client, null, 10);
-    IntegrationTestJob.runningHistory.clear();
+    IntegrationTestJob.RUNNING_HISTORY.clear();
 
     final Thread signal = this.getWorkerThread(worker, 2);
 
     signal.start();
     worker.run();
 
-    assertThat(IntegrationTestJob.runningHistory.get(0),
+    assertThat(IntegrationTestJob.RUNNING_HISTORY.get(0),
         equalTo(DEFAULT_JOB_NAME + ".process"));
   }
 
@@ -101,14 +101,14 @@ public class SerialWorkerTest extends IntegrationTest {
     final SerialWorker worker = new SerialWorker(
         Arrays.asList("testA", "testB", "testC"),
         this.client, null, 10);
-    IntegrationTestJob.runningHistory.clear();
+    IntegrationTestJob.RUNNING_HISTORY.clear();
 
     final Thread signal = this.getWorkerThread(worker, 3);
 
     signal.start();
     worker.run();
 
-    assertThat(IntegrationTestJob.runningHistory,
+    assertThat(IntegrationTestJob.RUNNING_HISTORY,
         contains(
             "com.moz.qless.IntegrationTestJob.testA",
             "com.moz.qless.IntegrationTestJob.testB",


### PR DESCRIPTION
This also renames it from `runningHistory` to `RUNNING_HISTORY` to match Java naming conventions.