### PR TITLE
Make Worker `-name` argument properly set Client workerName.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,9 +249,10 @@
       <version>1.7.25</version>
     </dependency>
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <version>3.5.1</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.7.22</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/moz/qless/SerialWorker.java
+++ b/src/main/java/com/moz/qless/SerialWorker.java
@@ -6,7 +6,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,7 +18,6 @@ public class SerialWorker {
   private final List<Queue> queues =
       new ArrayList<>();
 
-  private String workerName;
   private String currentJid;
   private final int intervalInSeconds;
 
@@ -29,7 +27,7 @@ public class SerialWorker {
   public SerialWorker(
       final List<String> queueNameList,
       final Client client,
-      final String workerName, final int intervalInSeconds) {
+      final int intervalInSeconds) {
 
     Preconditions.checkArgument(
         (null != queueNameList) && (!queueNameList.isEmpty()),
@@ -43,14 +41,6 @@ public class SerialWorker {
 
     this.client = client;
     this.intervalInSeconds = intervalInSeconds;
-
-    if (Strings.isNullOrEmpty(workerName)) {
-      this.setWorkerName(this.client.workerName());
-    } else {
-      this.setWorkerName(workerName
-          + "-"
-          + this.client.workerName());
-    }
 
     for (final String queueName : queueNameList) {
       this.queues.add(this.client.getQueue(queueName));
@@ -122,13 +112,5 @@ public class SerialWorker {
 
   public void setCurrentJid(final String currentJid) {
     this.currentJid = currentJid;
-  }
-
-  public String getWorkerName() {
-    return this.workerName;
-  }
-
-  private void setWorkerName(final String workerName) {
-    this.workerName = workerName;
   }
 }

--- a/src/main/java/com/moz/qless/Worker.java
+++ b/src/main/java/com/moz/qless/Worker.java
@@ -8,8 +8,6 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.spi.StringArrayOptionHandler;
 
-import redis.clients.jedis.JedisPool;
-
 public class Worker {
   @Option(name = "-host", usage = "The url to connect to Redis")
   public String host = "localhost";
@@ -36,13 +34,14 @@ public class Worker {
     }
 
     try {
-      final JedisPool jedisPool = new JedisPool(worker.host);
-      final Client client = new Client(jedisPool);
+      final Client client = Client.builder()
+        .jedisUri(worker.host)
+        .workerName(worker.name)
+        .build();
 
       final SerialWorker serialWorker = new SerialWorker(
           Arrays.asList(worker.queues),
           client,
-          worker.name,
           worker.inverval);
 
       serialWorker.run();

--- a/src/test/java/com/moz/qless/ClientTest.java
+++ b/src/test/java/com/moz/qless/ClientTest.java
@@ -65,6 +65,6 @@ public class ClientTest extends IntegrationTest {
 
   @Test
   public void redisUrlBasic() throws IOException {
-    new Client("redis://localhost:6379/");
+    Client.builder().jedisUri("redis://localhost:6379/").build();
   }
 }

--- a/src/test/java/com/moz/qless/EventsTest.java
+++ b/src/test/java/com/moz/qless/EventsTest.java
@@ -19,6 +19,7 @@ import com.moz.qless.event.QlessEventListener;
 import com.moz.qless.lua.LuaConfigParameter;
 
 public class EventsTest extends IntegrationTest {
+  private static final long SLEEP_MS = 500;
   private static final Logger LOGGER = LoggerFactory.getLogger(EventsTest.class);
   private Job untracked, tracked;
 
@@ -44,7 +45,7 @@ public class EventsTest extends IntegrationTest {
       .on("none")
       .fire(eventCapture);
 
-    Thread.sleep(100);
+    Thread.sleep(SLEEP_MS);
 
     assertThat(eventCapture.jidsForEvent("none"),
       is(empty()));
@@ -62,7 +63,7 @@ public class EventsTest extends IntegrationTest {
     this.tracked.cancel();
     this.untracked.cancel();
 
-    Thread.sleep(100);
+    Thread.sleep(SLEEP_MS);
 
     assertThat(eventCapture.jidsForEvent(JobStatus.CANCELED.toString()),
       hasSize(1));
@@ -83,7 +84,7 @@ public class EventsTest extends IntegrationTest {
       job.complete();
     }
 
-    Thread.sleep(100);
+    Thread.sleep(SLEEP_MS);
 
     assertThat(eventCapture.jidsForEvent(JobStatus.COMPLETED.toString()),
       hasSize(1));
@@ -104,7 +105,7 @@ public class EventsTest extends IntegrationTest {
       job.fail("foo", "bar");
     }
 
-    Thread.sleep(100);
+    Thread.sleep(SLEEP_MS);
 
     assertThat(eventCapture.jidsForEvent(JobStatus.FAILED.toString()),
       hasSize(1));
@@ -123,7 +124,7 @@ public class EventsTest extends IntegrationTest {
 
     this.queue.pop(10);
 
-    Thread.sleep(100);
+    Thread.sleep(SLEEP_MS);
 
     assertThat(eventCapture.jidsForEvent(JobStatus.POPPED.toString()),
       hasSize(1));
@@ -143,7 +144,7 @@ public class EventsTest extends IntegrationTest {
     this.tracked.requeue("other");
     this.untracked.requeue("other");
 
-    Thread.sleep(100);
+    Thread.sleep(SLEEP_MS);
 
     assertThat(eventCapture.jidsForEvent(JobStatus.PUT.toString()),
       hasSize(1));
@@ -170,7 +171,7 @@ public class EventsTest extends IntegrationTest {
     this.queue.pop(2);
     this.queue.pop(2);
 
-    Thread.sleep(100);
+    Thread.sleep(SLEEP_MS);
 
     assertThat(eventCapture.jidsForEvent(JobStatus.STALLED.toString()),
       hasSize(1));

--- a/src/test/java/com/moz/qless/IntegrationTest.java
+++ b/src/test/java/com/moz/qless/IntegrationTest.java
@@ -36,6 +36,6 @@ public class IntegrationTest {
       jedis.flushDB();
     }
 
-    return new Client(this.jedisPool);
+    return Client.builder().jedisPool(this.jedisPool).build();
   }
 }

--- a/src/test/java/com/moz/qless/SerialWorkerTest.java
+++ b/src/test/java/com/moz/qless/SerialWorkerTest.java
@@ -34,7 +34,7 @@ public class SerialWorkerTest extends IntegrationTest {
 
     final SerialWorker worker = new SerialWorker(
         Arrays.asList(DEFAULT_QUEUE_NAME),
-        this.client, null, 10);
+        this.client, 10);
     IntegrationTestJob.RUNNING_HISTORY.clear();
 
     final Thread signal = this.getWorkerThread(worker, 2);
@@ -42,10 +42,7 @@ public class SerialWorkerTest extends IntegrationTest {
     signal.start();
     worker.run();
 
-    assertThat(worker.getCurrentJid(),
-        equalTo(jid));
-    assertThat(worker.getWorkerName(),
-        equalTo(this.client.workerName()));
+    assertThat(worker.getCurrentJid(), equalTo(jid));
   }
 
   @Test
@@ -55,7 +52,7 @@ public class SerialWorkerTest extends IntegrationTest {
 
     final SerialWorker worker = new SerialWorker(
         Arrays.asList(DEFAULT_QUEUE_NAME),
-        this.client, null, 10);
+        this.client, 10);
     IntegrationTestJob.RUNNING_HISTORY.clear();
 
     final Thread signal = this.getWorkerThread(worker, 2);
@@ -74,7 +71,7 @@ public class SerialWorkerTest extends IntegrationTest {
 
     final SerialWorker worker = new SerialWorker(
         Arrays.asList("foo"),
-        this.client, null, 10);
+        this.client, 10);
     IntegrationTestJob.RUNNING_HISTORY.clear();
 
     final Thread signal = this.getWorkerThread(worker, 2);
@@ -100,7 +97,7 @@ public class SerialWorkerTest extends IntegrationTest {
 
     final SerialWorker worker = new SerialWorker(
         Arrays.asList("testA", "testB", "testC"),
-        this.client, null, 10);
+        this.client, 10);
     IntegrationTestJob.RUNNING_HISTORY.clear();
 
     final Thread signal = this.getWorkerThread(worker, 3);

--- a/src/test/java/com/moz/qless/utils/JsonUtilsTest.java
+++ b/src/test/java/com/moz/qless/utils/JsonUtilsTest.java
@@ -7,12 +7,12 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
-import org.easymock.EasyMock;
 import org.junit.Test;
 
 import com.moz.qless.Client;
@@ -27,7 +27,7 @@ public class JsonUtilsTest {
 
     final InjectableValues injectables = new InjectableValues.Std().addValue(
         Client.class,
-        EasyMock.createNiceMock(Client.class));
+        mock(Client.class));
     final Job job = JsonUtils.parse(json, Job.class, injectables);
 
     assertThat(job.getJid(),
@@ -93,7 +93,7 @@ public class JsonUtilsTest {
             Charset.defaultCharset());
     final InjectableValues injectables = new InjectableValues.Std().addValue(
         Client.class,
-        EasyMock.createNiceMock(Client.class));
+        mock(Client.class));
 
     final JavaType javaType = new ObjectMapper().getTypeFactory()
         .constructCollectionType(ArrayList.class, Job.class);

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Switched Client over to Builder pattern since its constructors were already getting complicated.

Switched tests to use Mockito instead of EasyMock due to ease of mocking final classes because the Builder pattern made Client final.

Also, ensured Mockito was in test scope which EasyMock was not correctly in the right dependency scope previously.