### PR TITLE
Log4j version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.9.1</version>
+      <version>2.15.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
To address critical vulnerability in log4j.
2.9.1 > 2.15.0

https://fossa.com/blog/log4j-log4shell-zero-day-vulnerability-impact-fixes/