### PR TITLE
Fixing several build bugs with new Jedis Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,32 @@
     </repository>
   </distributionManagement>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>http://insecure.repo1.maven.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <releases>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+    </pluginRepository>
+  </pluginRepositories>
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>http://insecure.repo1.maven.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <build>
     <defaultGoal>package</defaultGoal>
     <plugins>

--- a/provision.sh
+++ b/provision.sh
@@ -3,10 +3,10 @@
 set -e
 
 # JDK 8
-sudo add-apt-repository -y ppa:webupd8team/java
+sudo -E add-apt-repository ppa:openjdk-r/ppa
 echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
 sudo apt-get update
-sudo apt-get install -y oracle-java8-installer
+sudo apt-get install -y openjdk-8-jdk
 
 # Some dependencies
 sudo apt-get update

--- a/src/main/java/com/moz/qless/lua/LuaScript.java
+++ b/src/main/java/com/moz/qless/lua/LuaScript.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class LuaScript {
   private static final Logger LOGGER = LoggerFactory.getLogger(LuaScript.class);


### PR DESCRIPTION
- Maven no longer supports http calls unless done through their insecure endpoint https://blog.sonatype.com/central-repository-moving-to-https. Rather than overcomplicate this by converting to `https` I've swapped to use the insecure `http` endpoint.

- Oracle Java 8 is no longer available in the way it used to be. Swap to using OpenJDK 8.

- `redis.clients.util.SafeEncoder` has been moved to `redis.clients.jedis.util.SafeEncoder` in the new version of Jedis.